### PR TITLE
Add 2025-2026 exams section with Q1 links

### DIFF
--- a/book/changelog.md
+++ b/book/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 19-11-2025: v2025.38.0
+- Added exam Q1 to [](./exams.md)
 
 ## 18-11-2025: v2025.37.4
 - Added WS 2.2 to [overview week 2.2](./2025/overview/2_2.md)

--- a/book/exams.md
+++ b/book/exams.md
@@ -12,6 +12,11 @@ The formula sheet for the Q1 2025 exam is provided [here](https://files.mude.cit
 
 An example of a previous formula sheet is provided [here](https://archive.mude.citg.tudelft.nl/2024/files/Exams/Sample_Formula_Sheet.pdf)
 
+## 2025-2026 exams
+
+- 2025-2026 Q1 exam: [`.pdf` as provided during exam](https://github.com/TUDelft-MUDE/source-files/raw/main/file/MUDE-exam_Q1_2025.pdf) and [`.pdf` including answer](https://github.com/TUDelft-MUDE/source-files/raw/main/file/MUDE-exam-answers_Q1_2025.pdf)
+
+
 ## 2024-2025 exams
 
 Some changes:


### PR DESCRIPTION
Added information about the 2025-2026 exams and provided links to the Q1 exam and answer PDFs.

To be merge together with https://github.com/TUDelft-MUDE/source-files/pull/1